### PR TITLE
Fix(ci): Replace flyctl-actions with direct CLI installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: superfly/flyctl-actions@v0.0.29
+      - name: Install flyctl
+        run: |
+          curl -L https://fly.io/install.sh | sh
+          export FLYCTL_INSTALL="/home/runner/.fly"
+          export PATH="$FLYCTL_INSTALL/bin:$PATH"
+          echo "FLYCTL_INSTALL=/home/runner/.fly" >> $GITHUB_ENV
+          echo "$FLYCTL_INSTALL/bin" >> $GITHUB_PATH
       
       - name: Deploy to Fly.io
         run: flyctl deploy


### PR DESCRIPTION
Resolves deployment issues by installing flyctl CLI directly using the official installation script instead of relying on third-party GitHub Actions.

Relevant Global Rules: #5 (CI required).